### PR TITLE
[SWUI-22][IMPROV] - Change color tiles to the left, to align it or use a grid

### DIFF
--- a/apps/website/app/ui/page.tsx
+++ b/apps/website/app/ui/page.tsx
@@ -49,6 +49,7 @@ import {
 
 import { ThemeSwitch } from "@/components";
 
+const colorsKeysBanList = ["transparent", "inherit"];
 const fullConfig = resolveConfig(tailwindConfig);
 
 function extractStringValuesFromObject(object: any): string[] {
@@ -73,10 +74,13 @@ function extractStringValuesFromObject(object: any): string[] {
 const tailwindColors: { [key: string]: Array<string> } = Object.keys(
   fullConfig.theme.colors
 ).reduce(
-  (acc, key) => ({
-    ...acc,
-    [key]: extractStringValuesFromObject(fullConfig.theme.colors[key]),
-  }),
+  (acc, key) =>
+    colorsKeysBanList.some((colorName) => colorName === key)
+      ? acc
+      : {
+          ...acc,
+          [key]: extractStringValuesFromObject(fullConfig.theme.colors[key]),
+        },
   {}
 );
 
@@ -798,13 +802,13 @@ export default function UI() {
             {Object.keys(tailwindColors).map((key) => (
               <div key={key} className="space-y-2">
                 <p className="text-xl capitalize">{key}</p>
-                <div className="space-y-2">
+                <div className="space-y-2 grid grid-cols-3">
                   {tailwindColors[key].map((color) => (
                     <div key={color} className="flex space-x-4">
-                      <p>{`${key}-${color}`}</p>
                       <div
                         className={`bg-${key}-${color} w-20 h-10 rounded-6`}
                       />
+                      <p>{`${key}-${color}`}</p>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Fixes: [SWUI-22](https://linear.app/swaprhq/issue/SWUI-22/change-color-tiles-to-the-left-to-align-it-or-use-a-grid)

# Description
* Break the single long colors column into three columns
* Switch color names and color samples from place
* Filter out `transparent` and `inherit` colors

# Visual Evidence
<img width="1131" alt="Screenshot 2024-06-04 at 13 57 45" src="https://github.com/SwaprHQ/swapr-ui/assets/21271189/bc62817a-72b2-41a6-af7c-034f0aea034d">

# How to test the changes
1) Pull this branch
2) Run the Website project locally
3) Go to the main page
5) The Colors section should be displaying a 3 column grid layout, with the color samples on the left and the color names on the right
 

