### PR TITLE
[SWUI-21][DOCS] - Add ButtonLink example Swapr-ui website

### DIFF
--- a/apps/website/app/ui/page.tsx
+++ b/apps/website/app/ui/page.tsx
@@ -45,6 +45,7 @@ import {
   Dialog,
   DialogClose,
   DialogFooter,
+  ButtonLink,
 } from "swapr-ui";
 
 import { ThemeSwitch } from "@/components";
@@ -92,6 +93,15 @@ interface ButtonListProps {
   colorScheme?: ButtonColorSchemeProp;
 }
 
+interface ButtonLinkListProps {
+  active?: boolean;
+  as?: any;
+  children: string;
+  colorScheme?: ButtonColorSchemeProp;
+  disabled?: boolean;
+  variant?: ButtonVariantProp;
+}
+
 const buttonsList: Array<Array<ButtonListProps>> = [
   [
     { children: "Primary" },
@@ -135,6 +145,63 @@ const buttonsList: Array<Array<ButtonListProps>> = [
     },
   ],
 ];
+
+const buttonLinkList: {
+  headers: Array<string>;
+  rows: Array<Array<ButtonLinkListProps>>;
+} = {
+  headers: ["Primary", "Secondary", "Outline", "Active", "Disabled", "Ghost"],
+  rows: [
+    [
+      { children: "Normal" },
+      { children: "Normal", variant: "pastel" },
+      { children: "Normal", variant: "outline" },
+      { children: "Normal", active: true },
+      { children: "Normal", disabled: true },
+      { children: "Normal", variant: "ghost" },
+    ],
+    [
+      { children: "Error", colorScheme: "error" },
+      {
+        children: "Error",
+        colorScheme: "error",
+        variant: "pastel",
+      },
+      { children: "Error", colorScheme: "error", variant: "outline" },
+      { children: "Error", colorScheme: "error", active: true },
+      { children: "Error", colorScheme: "error", disabled: true },
+      { children: "Error", colorScheme: "error", variant: "ghost" },
+    ],
+    [
+      { children: "Success", colorScheme: "success" },
+      {
+        children: "Success",
+        colorScheme: "success",
+        variant: "pastel",
+      },
+      {
+        children: "Success",
+        colorScheme: "success",
+        variant: "outline",
+      },
+      { children: "Success", colorScheme: "success", active: true },
+      {
+        children: "Success",
+        colorScheme: "success",
+        disabled: true,
+      },
+      { children: "Success", colorScheme: "success", variant: "ghost" },
+    ],
+    [
+      { children: "As anchor", as: "a" },
+      { children: "As anchor", as: "a", variant: "pastel" },
+      { children: "As anchor", as: "a", variant: "outline" },
+      { children: "As anchor", as: "a", active: true },
+      { children: "As anchor", as: "a", disabled: true },
+      { children: "As anchor", as: "a", variant: "ghost" },
+    ],
+  ],
+};
 
 interface IconBadgeListProps {
   colorScheme?: IconBadgeColorSchemeProp;
@@ -328,6 +395,22 @@ export default function UI() {
               ))}
             </div>
           ))}
+        </Section>
+        <Section>
+          <h2 className="text-2xl font-semibold">ButtonLinks</h2>
+          <div className="grid space-y-2.5 lg:space-y-0 lg:grid-cols-6 lg:gap-4">
+            {buttonLinkList.headers.map((header, index) => (
+              <div
+                key={index}
+                className="hidden uppercase text-lg lg:block font-bold bg-gray-200 text-center"
+              >
+                {header}
+              </div>
+            ))}
+            {buttonLinkList.rows.flat().map((button, index) => (
+              <ButtonLink {...button} key={index} />
+            ))}
+          </div>
         </Section>
         <Section>
           <h2 className="text-2xl font-semibold">Chip Buttons</h2>
@@ -716,7 +799,6 @@ export default function UI() {
             ))}
           </div>
         </Section>
-
         <Section>
           <h2 className="text-2xl font-semibold">Logos</h2>
           <div className="space-y-4">
@@ -745,7 +827,6 @@ export default function UI() {
             ))}
           </div>
         </Section>
-
         <Section>
           <h2 className="text-2xl font-semibold">Font sizes</h2>
           <div className="space-y-2">

--- a/apps/website/app/ui/page.tsx
+++ b/apps/website/app/ui/page.tsx
@@ -901,14 +901,14 @@ const ButtonsSection = ({ children, btnList }: ButtonSectionProps) => (
       {btnList.headers.map((header, index) => (
         <div
           key={index}
-          className="hidden uppercase text-sm lg:block font-bold bg-gray-200 text-center"
+          className="hidden uppercase text-xs lg:block font-semibold bg-gray-200 text-center"
         >
           {header}
         </div>
       ))}
       {btnList.comboNames.map((combName, rowIndex) => (
         <Fragment key={rowIndex}>
-          <div className="hidden uppercase text-sm lg:block font-bold bg-gray-200 p-2 text-center">
+          <div className="hidden uppercase text-xs lg:block font-semibold bg-gray-200 p-2 text-center">
             {combName}
           </div>
           {btnList.combos[rowIndex].map((button, colIndex) => (

--- a/apps/website/app/ui/page.tsx
+++ b/apps/website/app/ui/page.tsx
@@ -191,11 +191,11 @@ const btnLinkList: {
   ],
   comboNames: [
     "Normal",
-    "As Button (N)",
+    "As Button, Normal",
     "Success",
-    "As Button (S)",
+    "As Button, Success",
     "Error",
-    "As Button (E)",
+    "As Button, Error",
   ],
   combos: [
     regularBLCombos,
@@ -897,18 +897,18 @@ interface ButtonSectionProps extends PropsWithChildren {
 const ButtonsSection = ({ children, btnList }: ButtonSectionProps) => (
   <Section>
     <h2 className="text-2xl font-semibold">{children}</h2>
-    <div className="grid space-y-2.5 lg:space-y-0 lg:grid-cols-8 lg:gap-4">
+    <div className="grid items-center space-y-2.5 lg:space-y-0 lg:grid-cols-8 lg:gap-4">
       {btnList.headers.map((header, index) => (
         <div
           key={index}
-          className="hidden uppercase text-md lg:block font-bold bg-gray-200 text-center"
+          className="hidden uppercase text-sm lg:block font-bold bg-gray-200 text-center"
         >
           {header}
         </div>
       ))}
       {btnList.comboNames.map((combName, rowIndex) => (
         <Fragment key={rowIndex}>
-          <div className="hidden uppercase text-md lg:block font-bold bg-gray-200 p-2 text-center">
+          <div className="hidden uppercase text-sm lg:block font-bold bg-gray-200 p-2 text-center">
             {combName}
           </div>
           {btnList.combos[rowIndex].map((button, colIndex) => (

--- a/apps/website/app/ui/page.tsx
+++ b/apps/website/app/ui/page.tsx
@@ -102,104 +102,108 @@ interface ButtonLinkListProps {
   variant?: ButtonVariantProp;
 }
 
-const buttonsList: Array<Array<ButtonListProps>> = [
-  [
-    { children: "Primary" },
-    { children: "Disabled", disabled: true },
-    { children: "Primary active", active: true },
-    { children: "Secondary", variant: "pastel" },
-    { children: "Outline", variant: "outline" },
-    { children: "Ghost", variant: "ghost" },
-    { children: "Ghost disabled", variant: "ghost", disabled: true },
-  ],
-  [
-    { children: "Error", colorScheme: "error" },
-    { children: "Error disabled", colorScheme: "error", disabled: true },
-    { children: "Error active", colorScheme: "error", active: true },
-    { children: "Error secondary", colorScheme: "error", variant: "pastel" },
-    { children: "Error outline", colorScheme: "error", variant: "outline" },
-    { children: "Error ghost", colorScheme: "error", variant: "ghost" },
-    {
-      children: "Error ghost disabled",
-      colorScheme: "error",
-      variant: "ghost",
-      disabled: true,
-    },
-  ],
-  [
-    { children: "Success", colorScheme: "success" },
-    { children: "Success disabled", colorScheme: "success", disabled: true },
-    { children: "Success active", colorScheme: "success", active: true },
-    {
-      children: "Success secondary",
-      colorScheme: "success",
-      variant: "pastel",
-    },
-    { children: "Success outline", colorScheme: "success", variant: "outline" },
-    { children: "Success ghost", colorScheme: "success", variant: "ghost" },
-    {
-      children: "Success ghost disabled",
-      colorScheme: "success",
-      variant: "ghost",
-      disabled: true,
-    },
-  ],
+const getBtnCombos = (children: string = "Button"): Array<ButtonListProps> => [
+  { children },
+  { children, variant: "pastel" },
+  { children, variant: "outline" },
+  { children, variant: "ghost" },
+  { children, active: true },
+  { children, disabled: true },
+  { children, variant: "ghost", disabled: true },
 ];
 
-const buttonLinkList: {
+type ExtendedButtonProps = Omit<ButtonListProps, "children">;
+type ExtendedButtonLinkProps = Omit<ButtonLinkListProps, "children">;
+const extendBtnCombos = (
+  btnPropsList: Array<ButtonListProps>,
+  newProp: ExtendedButtonProps | ExtendedButtonLinkProps
+): Array<ButtonListProps> =>
+  btnPropsList.map((buttonProps) => ({
+    ...buttonProps,
+    ...newProp,
+  }));
+
+const regularBtnCombos: Array<ButtonLinkListProps> = getBtnCombos();
+const successBtnCombos: Array<ButtonLinkListProps> = extendBtnCombos(
+  regularBtnCombos,
+  { colorScheme: "success" }
+);
+const errorBtnCombos: Array<ButtonLinkListProps> = extendBtnCombos(
+  regularBtnCombos,
+  { colorScheme: "error" }
+);
+
+const buttonsList: {
   headers: Array<string>;
-  rows: Array<Array<ButtonLinkListProps>>;
+  comboNames: Array<string>;
+  combos: Array<Array<ButtonLinkListProps>>;
 } = {
-  headers: ["Primary", "Secondary", "Outline", "Active", "Disabled", "Ghost"],
-  rows: [
-    [
-      { children: "Normal" },
-      { children: "Normal", variant: "pastel" },
-      { children: "Normal", variant: "outline" },
-      { children: "Normal", active: true },
-      { children: "Normal", disabled: true },
-      { children: "Normal", variant: "ghost" },
-    ],
-    [
-      { children: "Error", colorScheme: "error" },
-      {
-        children: "Error",
-        colorScheme: "error",
-        variant: "pastel",
-      },
-      { children: "Error", colorScheme: "error", variant: "outline" },
-      { children: "Error", colorScheme: "error", active: true },
-      { children: "Error", colorScheme: "error", disabled: true },
-      { children: "Error", colorScheme: "error", variant: "ghost" },
-    ],
-    [
-      { children: "Success", colorScheme: "success" },
-      {
-        children: "Success",
-        colorScheme: "success",
-        variant: "pastel",
-      },
-      {
-        children: "Success",
-        colorScheme: "success",
-        variant: "outline",
-      },
-      { children: "Success", colorScheme: "success", active: true },
-      {
-        children: "Success",
-        colorScheme: "success",
-        disabled: true,
-      },
-      { children: "Success", colorScheme: "success", variant: "ghost" },
-    ],
-    [
-      { children: "As anchor", as: "a" },
-      { children: "As anchor", as: "a", variant: "pastel" },
-      { children: "As anchor", as: "a", variant: "outline" },
-      { children: "As anchor", as: "a", active: true },
-      { children: "As anchor", as: "a", disabled: true },
-      { children: "As anchor", as: "a", variant: "ghost" },
-    ],
+  headers: [
+    "",
+    "Primary",
+    "Secondary",
+    "Outline",
+    "Ghost",
+    "Active",
+    "Disabled",
+    "Ghost Disabled",
+  ],
+  comboNames: ["Normal", "Success", "Error"],
+  combos: [regularBtnCombos, successBtnCombos, errorBtnCombos],
+};
+
+const regularBLCombos: Array<ButtonLinkListProps> = getBtnCombos("ButtonLink");
+const regularAsElemBLCombos: Array<ButtonLinkListProps> = extendBtnCombos(
+  regularBLCombos,
+  { as: Button }
+);
+const successBLCombos: Array<ButtonLinkListProps> = extendBtnCombos(
+  regularBLCombos,
+  { colorScheme: "success" }
+);
+const successAsElemBLCombos: Array<ButtonLinkListProps> = extendBtnCombos(
+  successBLCombos,
+  { as: Button }
+);
+const errorBLCombos: Array<ButtonLinkListProps> = extendBtnCombos(
+  regularBLCombos,
+  { colorScheme: "error" }
+);
+const errorAsElemBLCombos: Array<ButtonLinkListProps> = extendBtnCombos(
+  errorBLCombos,
+  { as: Button }
+);
+
+const btnLinkList: {
+  headers: Array<string>;
+  comboNames: Array<string>;
+  combos: Array<Array<ButtonLinkListProps>>;
+} = {
+  headers: [
+    "",
+    "Primary",
+    "Secondary",
+    "Outline",
+    "Ghost",
+    "Active",
+    "Disabled",
+    "Ghost Disabled",
+  ],
+  comboNames: [
+    "Normal",
+    "As Button (N)",
+    "Success",
+    "As Button (S)",
+    "Error",
+    "As Button (E)",
+  ],
+  combos: [
+    regularBLCombos,
+    regularAsElemBLCombos,
+    successBLCombos,
+    successAsElemBLCombos,
+    errorBLCombos,
+    errorAsElemBLCombos,
   ],
 };
 
@@ -386,32 +390,8 @@ export default function UI() {
           <h1 className="text-3xl font-bold">Swapr UI</h1>
           <p>A set of components to build apps faster.</p>
         </div>
-        <Section>
-          <h2 className="text-2xl font-semibold">Buttons</h2>
-          {buttonsList.map((row, i) => (
-            <div key={i} className="flex space-x-2">
-              {row.map((button, j) => (
-                <Button {...button} key={j} />
-              ))}
-            </div>
-          ))}
-        </Section>
-        <Section>
-          <h2 className="text-2xl font-semibold">ButtonLinks</h2>
-          <div className="grid space-y-2.5 lg:space-y-0 lg:grid-cols-6 lg:gap-4">
-            {buttonLinkList.headers.map((header, index) => (
-              <div
-                key={index}
-                className="hidden uppercase text-lg lg:block font-bold bg-gray-200 text-center"
-              >
-                {header}
-              </div>
-            ))}
-            {buttonLinkList.rows.flat().map((button, index) => (
-              <ButtonLink {...button} key={index} />
-            ))}
-          </div>
-        </Section>
+        <ButtonsSection btnList={buttonsList}>Buttons</ButtonsSection>
+        <ButtonsSection btnList={btnLinkList}>ButtonLinks</ButtonsSection>
         <Section>
           <h2 className="text-2xl font-semibold">Chip Buttons</h2>
           {chipButtonList.map((row, i) => (
@@ -905,3 +885,37 @@ export default function UI() {
 const Section = ({ children }: PropsWithChildren) => {
   return <section className="space-y-4 py-12 border-b">{children}</section>;
 };
+
+interface ButtonSectionProps extends PropsWithChildren {
+  btnList: {
+    headers: Array<string>;
+    comboNames: Array<string>;
+    combos: Array<Array<ButtonListProps | ButtonLinkListProps>>;
+  };
+}
+
+const ButtonsSection = ({ children, btnList }: ButtonSectionProps) => (
+  <Section>
+    <h2 className="text-2xl font-semibold">{children}</h2>
+    <div className="grid space-y-2.5 lg:space-y-0 lg:grid-cols-8 lg:gap-4">
+      {btnList.headers.map((header, index) => (
+        <div
+          key={index}
+          className="hidden uppercase text-md lg:block font-bold bg-gray-200 text-center"
+        >
+          {header}
+        </div>
+      ))}
+      {btnList.comboNames.map((combName, rowIndex) => (
+        <Fragment key={rowIndex}>
+          <div className="hidden uppercase text-md lg:block font-bold bg-gray-200 p-2 text-center">
+            {combName}
+          </div>
+          {btnList.combos[rowIndex].map((button, colIndex) => (
+            <ButtonLink {...button} key={colIndex} />
+          ))}
+        </Fragment>
+      ))}
+    </div>
+  </Section>
+);

--- a/packages/ui/src/components/Button/styles.ts
+++ b/packages/ui/src/components/Button/styles.ts
@@ -4,7 +4,7 @@ export const buttonStyles = cva(
   [
     "flex items-center justify-center h-fit",
     "select-none font-semibold",
-    "disabled:text-text-disabled disabled:cursor-not-allowed disabled:ring-0 disabled:shadow-inherit",
+    "disabled:text-text-disabled disabled:cursor-not-allowed disabled:ring-0",
     "focus-visible:outline-none focus-visible:ring-[3px]",
     "active:ring-[3px]",
   ],
@@ -51,7 +51,7 @@ export const buttonStyles = cva(
         variant: "solid",
         colorScheme: "primary",
         class: [
-          "bg-surface-primary-main text-text-white shadow-button",
+          "bg-surface-primary-main text-text-white",
           "hover:bg-surface-primary-accent-3",
           "focus-visible:bg-surface-primary-accent-3 focus-visible:ring-outline-primary-low-em",
           "active:bg-surface-primary-accent-3 active:ring-outline-primary-low-em",
@@ -90,7 +90,7 @@ export const buttonStyles = cva(
         variant: "solid",
         colorScheme: "error",
         class: [
-          "bg-surface-danger-main text-text-white shadow-button",
+          "bg-surface-danger-main text-text-white",
           "hover:bg-surface-danger-accent-3",
           "focus-visible:bg-surface-danger-accent-3",
           "active:bg-surface-danger-accent-3",
@@ -130,7 +130,7 @@ export const buttonStyles = cva(
         variant: "solid",
         colorScheme: "success",
         class: [
-          "bg-surface-success-main shadow-button",
+          "bg-surface-success-main",
           "hover:bg-surface-success-accent-3",
           "focus-visible:bg-surface-success-accent-3",
           "active:bg-surface-success-accent-3",
@@ -170,7 +170,7 @@ export const buttonStyles = cva(
         colorScheme: "primary",
         variant: "solid",
         active: true,
-        class: "!bg-surface-primary-accent-3 ring-outline-primary-low-em",
+        class: "bg-surface-primary-accent-3 ring-outline-primary-low-em",
       },
       {
         colorScheme: "primary",
@@ -194,13 +194,13 @@ export const buttonStyles = cva(
         colorScheme: "error",
         variant: "solid",
         active: true,
-        class: "!bg-surface-danger-accent-3 ring-outline-danger-low-em",
+        class: "bg-surface-danger-accent-3 ring-outline-danger-low-em",
       },
       {
         colorScheme: "success",
         variant: "solid",
         active: true,
-        class: "!bg-surface-success-accent-3 ring-outline-success-low-em",
+        class: "bg-surface-success-accent-3 ring-outline-success-low-em",
       },
     ],
     defaultVariants: {

--- a/packages/ui/src/components/ButtonLink/ButtonLink.stories.tsx
+++ b/packages/ui/src/components/ButtonLink/ButtonLink.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 
 export const AsAnchor: StoryFn<ButtonLinkProps<"a">> = (args) => (
   <ButtonLink href="/" {...args}>
-    As button
+    As anchor
   </ButtonLink>
 );
 

--- a/packages/ui/src/components/ButtonLink/ButtonLink.tsx
+++ b/packages/ui/src/components/ButtonLink/ButtonLink.tsx
@@ -1,3 +1,4 @@
+import { cva } from "class-variance-authority";
 import { twMerge } from "tailwind-merge";
 
 import { ButtonProps, buttonStyles } from "../Button";
@@ -7,34 +8,107 @@ export type ButtonLinkProps<T extends React.ElementType> =
     React.ComponentPropsWithoutRef<T> &
       Pick<
         ButtonProps,
-        "active" | "colorScheme" | "size" | "variant" | "width"
+        "active" | "colorScheme" | "disabled" | "size" | "variant" | "width"
       > & {
         as?: T;
       }
   >;
+
+const buttonLinkStyles = cva(["cursor-pointer"], {
+  variants: {
+    colorScheme: {
+      primary: [],
+      error: [],
+      success: [],
+    },
+    variant: {
+      solid: [],
+      pastel: [],
+      outline: [],
+      ghost: [],
+    },
+    active: {
+      true: [],
+    },
+    disabled: {
+      true: ["text-text-disabled pointer-events-none ring-0"],
+    },
+  },
+  compoundVariants: [
+    {
+      colorScheme: "primary",
+      variant: "outline",
+      class: "text-inherit",
+    },
+    {
+      colorScheme: "primary",
+      variant: "ghost",
+      class: "text-inherit",
+    },
+    {
+      colorScheme: "success",
+      variant: "solid",
+      class: "text-inherit",
+    },
+    {
+      colorScheme: "success",
+      active: true,
+      class: "text-inherit",
+    },
+    {
+      disabled: true,
+      variant: "ghost",
+      class: ["bg-inherit text-text-disabled"],
+    },
+    {
+      disabled: true,
+      variant: ["solid", "outline", "pastel"],
+      class: ["bg-surface-disabled-low-em text-text-disabled"],
+    },
+    {
+      colorScheme: ["primary", "error", "success"],
+      variant: "ghost",
+      class: "bg-inherit",
+    },
+  ],
+  defaultVariants: {
+    active: false,
+    disabled: false,
+    colorScheme: "primary",
+    variant: "solid",
+  },
+});
+
+const DEFAULT_ELEMENT = "a";
 
 export function ButtonLink<T extends React.ElementType = "a">({
   active,
   as,
   className,
   colorScheme,
+  disabled,
   size,
   variant,
   width,
   ...props
 }: ButtonLinkProps<T>) {
-  const Component = as || "a";
+  const Component = as || DEFAULT_ELEMENT;
 
   return (
     <Component
       className={twMerge(
         buttonStyles({
           active,
-          className,
           colorScheme,
           size,
           variant,
           width,
+        }),
+        buttonLinkStyles({
+          active,
+          colorScheme,
+          disabled,
+          variant,
         }),
         className
       )}


### PR DESCRIPTION
## Fixes: [SWUI-21](https://linear.app/swaprhq/issue/SWUI-21/add-buttonlink-example-swapr-ui-website)

# Description
* Correct a wrong label for `ButtonLink` stories
* Correct wrong styles on `ButtonLink` and `Button` components
* Add `ButtonLink` examples in Swapr UI website
* Update how we display `Button` examples in Swapr UI website

# Visual Evidence
<img width="1512" alt="Screenshot 2024-06-13 at 18 23 19" src="https://github.com/SwaprHQ/swapr-ui/assets/21271189/4b56b2dc-b9bf-47c0-b0d5-a192f69b07db">

<img width="416" alt="Screenshot 2024-06-11 at 11 52 11" src="https://github.com/SwaprHQ/swapr-ui/assets/21271189/90cac69a-1f86-4329-b5d2-98d8d880acd7">
