### PR TITLE
[SWUI-30][FIX] - Popover and ChipButton DOM errors

### DIFF
--- a/apps/website/components/PopoverSection/examples.tsx
+++ b/apps/website/components/PopoverSection/examples.tsx
@@ -1,8 +1,8 @@
+import { PropsWithChildren, useRef } from "react";
+
 import {
-  Button,
   ChipButton,
   Icon,
-  IconButton,
   Popover,
   PopoverContent,
   PopoverContentHeader,
@@ -12,6 +12,20 @@ import {
   TabStyled,
 } from "swapr-ui";
 import { Root as Separator } from "@radix-ui/react-separator";
+
+const TriggerElement = ({ children }: PropsWithChildren) => (
+  <div
+    className={`
+    bg-surface-primary-main text-text-white
+    hover:bg-surface-primary-accent-3
+    focus-visible:bg-surface-primary-accent-3 focus-visible:ring-outline-primary-low-em
+    active:bg-surface-primary-accent-3 active:ring-outline-primary-low-em
+    px-3 py-2 space-x-2 rounded-12 text-base font-bold
+  `}
+  >
+    {children}
+  </div>
+);
 
 const SettingsPopoverContent = () => (
   <div className="space-y-2">
@@ -52,36 +66,50 @@ const SettingsPopoverContent = () => (
   </div>
 );
 
-export const PopoverBasic = () => (
-  <Popover>
-    <PopoverTrigger>
-      <Button>Open Popup</Button>
-    </PopoverTrigger>
-    <PopoverContent>
-      <p>This is a basic content example</p>
-    </PopoverContent>
-  </Popover>
-);
+export const PopoverBasic = () => {
+  const basicRef = useRef(null);
 
-export const PopoverWithHeader = () => (
-  <Popover>
-    <PopoverTrigger>
-      <Button>With header</Button>
-    </PopoverTrigger>
-    <PopoverContent className="max-w-md px-0">
-      <PopoverContentHeader title="Settings" />
-      <SettingsPopoverContent />
-    </PopoverContent>
-  </Popover>
-);
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <TriggerElement>Open Popup</TriggerElement>
+      </PopoverTrigger>
+      <PopoverContent ref={basicRef}>
+        <p>This is a basic content example</p>
+      </PopoverContent>
+    </Popover>
+  );
+};
 
-export const PopoverSlippageSettings = () => (
-  <Popover>
-    <PopoverTrigger>
-      <IconButton name="settings" />
-    </PopoverTrigger>
-    <PopoverContent className="max-w-md px-0">
-      <SettingsPopoverContent />
-    </PopoverContent>
-  </Popover>
-);
+export const PopoverWithHeader = () => {
+  const withHeaderRef = useRef(null);
+
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <TriggerElement>With header</TriggerElement>
+      </PopoverTrigger>
+      <PopoverContent className="max-w-md px-0" ref={withHeaderRef}>
+        <PopoverContentHeader title="Settings" />
+        <SettingsPopoverContent />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export const PopoverSlippageSettings = () => {
+  const settingsRef = useRef(null);
+
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <TriggerElement>
+          <Icon name="settings" />
+        </TriggerElement>
+      </PopoverTrigger>
+      <PopoverContent className="max-w-md px-0" ref={settingsRef}>
+        <SettingsPopoverContent />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/website/components/PopoverSection/examples.tsx
+++ b/apps/website/components/PopoverSection/examples.tsx
@@ -1,8 +1,8 @@
-import { PropsWithChildren, useRef } from "react";
-
 import {
+  Button,
   ChipButton,
   Icon,
+  IconButton,
   Popover,
   PopoverContent,
   PopoverContentHeader,
@@ -12,20 +12,6 @@ import {
   TabStyled,
 } from "swapr-ui";
 import { Root as Separator } from "@radix-ui/react-separator";
-
-const TriggerElement = ({ children }: PropsWithChildren) => (
-  <div
-    className={`
-    bg-surface-primary-main text-text-white
-    hover:bg-surface-primary-accent-3
-    focus-visible:bg-surface-primary-accent-3 focus-visible:ring-outline-primary-low-em
-    active:bg-surface-primary-accent-3 active:ring-outline-primary-low-em
-    px-3 py-2 space-x-2 rounded-12 text-base font-bold
-  `}
-  >
-    {children}
-  </div>
-);
 
 const SettingsPopoverContent = () => (
   <div className="space-y-2">
@@ -66,50 +52,36 @@ const SettingsPopoverContent = () => (
   </div>
 );
 
-export const PopoverBasic = () => {
-  const basicRef = useRef(null);
+export const PopoverBasic = () => (
+  <Popover>
+    <PopoverTrigger asChild>
+      <Button>Open Popup</Button>
+    </PopoverTrigger>
+    <PopoverContent>
+      <p>This is a basic content example</p>
+    </PopoverContent>
+  </Popover>
+);
 
-  return (
-    <Popover>
-      <PopoverTrigger>
-        <TriggerElement>Open Popup</TriggerElement>
-      </PopoverTrigger>
-      <PopoverContent ref={basicRef}>
-        <p>This is a basic content example</p>
-      </PopoverContent>
-    </Popover>
-  );
-};
+export const PopoverWithHeader = () => (
+  <Popover>
+    <PopoverTrigger asChild>
+      <Button>With header</Button>
+    </PopoverTrigger>
+    <PopoverContent className="max-w-md px-0">
+      <PopoverContentHeader title="Settings" />
+      <SettingsPopoverContent />
+    </PopoverContent>
+  </Popover>
+);
 
-export const PopoverWithHeader = () => {
-  const withHeaderRef = useRef(null);
-
-  return (
-    <Popover>
-      <PopoverTrigger>
-        <TriggerElement>With header</TriggerElement>
-      </PopoverTrigger>
-      <PopoverContent className="max-w-md px-0" ref={withHeaderRef}>
-        <PopoverContentHeader title="Settings" />
-        <SettingsPopoverContent />
-      </PopoverContent>
-    </Popover>
-  );
-};
-
-export const PopoverSlippageSettings = () => {
-  const settingsRef = useRef(null);
-
-  return (
-    <Popover>
-      <PopoverTrigger>
-        <TriggerElement>
-          <Icon name="settings" />
-        </TriggerElement>
-      </PopoverTrigger>
-      <PopoverContent className="max-w-md px-0" ref={settingsRef}>
-        <SettingsPopoverContent />
-      </PopoverContent>
-    </Popover>
-  );
-};
+export const PopoverSlippageSettings = () => (
+  <Popover>
+    <PopoverTrigger asChild>
+      <IconButton name="settings" />
+    </PopoverTrigger>
+    <PopoverContent className="max-w-md px-0">
+      <SettingsPopoverContent />
+    </PopoverContent>
+  </Popover>
+);

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, Ref, forwardRef } from "react";
 
 import { twMerge } from "tailwind-merge";
 
@@ -18,31 +18,37 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   width?: WidthProp;
 }
 
-export const Button = ({
-  active,
-  children,
-  className,
-  colorScheme,
-  size,
-  variant,
-  width,
-  ...props
-}: ButtonProps) => {
-  return (
-    <button
-      className={twMerge(
-        buttonStyles({
-          active,
-          className,
-          colorScheme,
-          size,
-          variant,
-          width,
-        })
-      )}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-};
+export const Button = forwardRef(
+  (
+    {
+      active,
+      children,
+      className,
+      colorScheme,
+      size,
+      variant,
+      width,
+      ...props
+    }: ButtonProps,
+    ref: Ref<HTMLButtonElement>
+  ) => {
+    return (
+      <button
+        className={twMerge(
+          buttonStyles({
+            active,
+            className,
+            colorScheme,
+            size,
+            variant,
+            width,
+          })
+        )}
+        {...props}
+        ref={ref}
+      >
+        {children}
+      </button>
+    );
+  }
+);

--- a/packages/ui/src/components/ChipButton/ChipButton.tsx
+++ b/packages/ui/src/components/ChipButton/ChipButton.tsx
@@ -1,4 +1,5 @@
-import { ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, Ref, forwardRef } from "react";
+
 import { cva, cx } from "class-variance-authority";
 
 export const chipButtonStyles = cva(
@@ -63,15 +64,18 @@ interface ChipButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   active?: boolean;
 }
 
-export const ChipButton = ({
-  children,
-  size,
-  colorScheme,
-  active,
-  className,
-  ...props
-}: ChipButtonProps) => {
-  return (
+export const ChipButton = forwardRef(
+  (
+    {
+      children,
+      size,
+      colorScheme,
+      active,
+      className,
+      ...props
+    }: ChipButtonProps,
+    ref: Ref<HTMLButtonElement>
+  ) => (
     <button
       className={cx(
         chipButtonStyles({
@@ -85,5 +89,5 @@ export const ChipButton = ({
     >
       {children}
     </button>
-  );
-};
+  )
+);

--- a/packages/ui/src/components/IconButton/IconButton.tsx
+++ b/packages/ui/src/components/IconButton/IconButton.tsx
@@ -1,3 +1,5 @@
+import { forwardRef, Ref } from "react";
+
 import { cva } from "class-variance-authority";
 import { Button, ButtonProps, ButtonSizeProp } from "../Button";
 import { Icon, IconProps } from "../Icon";
@@ -23,15 +25,22 @@ const iconSize: Record<ButtonSizeProp, number> = {
   lg: 20,
 };
 
-export const IconButton = ({
-  name,
-  className,
-  size = "md",
-  ...props
-}: ButtonProps & Pick<IconProps, "name">) => {
-  return (
-    <Button className={iconButtonStyles({ className, size })} {...props}>
+export const IconButton = forwardRef(
+  (
+    {
+      name,
+      className,
+      size = "md",
+      ...props
+    }: ButtonProps & Pick<IconProps, "name">,
+    ref: Ref<HTMLButtonElement>
+  ) => (
+    <Button
+      className={iconButtonStyles({ className, size })}
+      {...props}
+      ref={ref}
+    >
       <Icon size={iconSize[size]} name={name} />
     </Button>
-  );
-};
+  )
+);

--- a/packages/ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/src/components/Popover/Popover.stories.tsx
@@ -10,7 +10,15 @@ import {
   PopoverTrigger,
 } from "./Popover";
 
-import { ChipButton, Icon, TabGroup, TabHeader, TabStyled } from "..";
+import {
+  Button,
+  ChipButton,
+  Icon,
+  IconButton,
+  TabGroup,
+  TabHeader,
+  TabStyled,
+} from "..";
 
 const meta = {
   title: "Components/Popover Content",
@@ -36,28 +44,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const TriggerElement = ({ children }: PropsWithChildren) => (
-  <div
-    className={`
-    bg-surface-primary-main text-text-white
-    hover:bg-surface-primary-accent-3
-    focus-visible:bg-surface-primary-accent-3 focus-visible:ring-outline-primary-low-em
-    active:bg-surface-primary-accent-3 active:ring-outline-primary-low-em
-    px-3 py-2 space-x-2 rounded-12 text-base font-bold
-  `}
-  >
-    {children}
-  </div>
-);
-
 export const Basic: Story = {
   render: (args) => {
     const basicRef = useRef(null);
 
     return (
       <Popover>
-        <PopoverTrigger className="ml-[400px] mt-4">
-          <TriggerElement>Open Popup</TriggerElement>
+        <PopoverTrigger asChild className="ml-[400px] mt-4">
+          <Button>Open Popup</Button>
         </PopoverTrigger>
         <PopoverContent {...args} ref={basicRef}>
           <p>This is a basic content example</p>
@@ -111,10 +105,8 @@ export const SlippageSettings: Story = {
 
     return (
       <Popover>
-        <PopoverTrigger className="ml-[400px] mt-4">
-          <TriggerElement>
-            <Icon name="settings" />
-          </TriggerElement>
+        <PopoverTrigger asChild className="ml-[400px] mt-4">
+          <IconButton name="settings" />
         </PopoverTrigger>
         <PopoverContent {...args} className="max-w-md px-0" ref={settingsRef}>
           <SettingsPopoverContent />
@@ -130,8 +122,8 @@ export const PopoverWithHeader: Story = {
 
     return (
       <Popover>
-        <PopoverTrigger className="ml-[400px] mt-4">
-          <TriggerElement>With header</TriggerElement>
+        <PopoverTrigger asChild className="ml-[400px] mt-4">
+          <Button>With header</Button>
         </PopoverTrigger>
         <PopoverContent {...args} className="max-w-md px-0" ref={withHeaderRef}>
           <PopoverContentHeader title="Settings" />

--- a/packages/ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/src/components/Popover/Popover.stories.tsx
@@ -1,5 +1,3 @@
-import { PropsWithChildren, useRef } from "react";
-
 import { Root as Separator } from "@radix-ui/react-separator";
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -45,20 +43,16 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-  render: (args) => {
-    const basicRef = useRef(null);
-
-    return (
-      <Popover>
-        <PopoverTrigger asChild className="ml-[400px] mt-4">
-          <Button>Open Popup</Button>
-        </PopoverTrigger>
-        <PopoverContent {...args} ref={basicRef}>
-          <p>This is a basic content example</p>
-        </PopoverContent>
-      </Popover>
-    );
-  },
+  render: (args) => (
+    <Popover>
+      <PopoverTrigger asChild className="ml-[400px] mt-4">
+        <Button>Open Popup</Button>
+      </PopoverTrigger>
+      <PopoverContent {...args}>
+        <p>This is a basic content example</p>
+      </PopoverContent>
+    </Popover>
+  ),
 };
 
 const SettingsPopoverContent = () => (
@@ -100,36 +94,28 @@ const SettingsPopoverContent = () => (
   </div>
 );
 export const SlippageSettings: Story = {
-  render: (args) => {
-    const settingsRef = useRef(null);
-
-    return (
-      <Popover>
-        <PopoverTrigger asChild className="ml-[400px] mt-4">
-          <IconButton name="settings" />
-        </PopoverTrigger>
-        <PopoverContent {...args} className="max-w-md px-0" ref={settingsRef}>
-          <SettingsPopoverContent />
-        </PopoverContent>
-      </Popover>
-    );
-  },
+  render: (args) => (
+    <Popover>
+      <PopoverTrigger asChild className="ml-[400px] mt-4">
+        <IconButton name="settings" />
+      </PopoverTrigger>
+      <PopoverContent {...args} className="max-w-md px-0">
+        <SettingsPopoverContent />
+      </PopoverContent>
+    </Popover>
+  ),
 };
 
 export const PopoverWithHeader: Story = {
-  render: (args) => {
-    const withHeaderRef = useRef(null);
-
-    return (
-      <Popover>
-        <PopoverTrigger asChild className="ml-[400px] mt-4">
-          <Button>With header</Button>
-        </PopoverTrigger>
-        <PopoverContent {...args} className="max-w-md px-0" ref={withHeaderRef}>
-          <PopoverContentHeader title="Settings" />
-          <SettingsPopoverContent />
-        </PopoverContent>
-      </Popover>
-    );
-  },
+  render: (args) => (
+    <Popover>
+      <PopoverTrigger asChild className="ml-[400px] mt-4">
+        <Button>With header</Button>
+      </PopoverTrigger>
+      <PopoverContent {...args} className="max-w-md px-0">
+        <PopoverContentHeader title="Settings" />
+        <SettingsPopoverContent />
+      </PopoverContent>
+    </Popover>
+  ),
 };

--- a/packages/ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/src/components/Popover/Popover.stories.tsx
@@ -1,3 +1,5 @@
+import { PropsWithChildren, useRef } from "react";
+
 import { Root as Separator } from "@radix-ui/react-separator";
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -8,15 +10,7 @@ import {
   PopoverTrigger,
 } from "./Popover";
 
-import {
-  Button,
-  ChipButton,
-  Icon,
-  IconButton,
-  TabGroup,
-  TabHeader,
-  TabStyled,
-} from "..";
+import { ChipButton, Icon, TabGroup, TabHeader, TabStyled } from "..";
 
 const meta = {
   title: "Components/Popover Content",
@@ -42,17 +36,35 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const TriggerElement = ({ children }: PropsWithChildren) => (
+  <div
+    className={`
+    bg-surface-primary-main text-text-white
+    hover:bg-surface-primary-accent-3
+    focus-visible:bg-surface-primary-accent-3 focus-visible:ring-outline-primary-low-em
+    active:bg-surface-primary-accent-3 active:ring-outline-primary-low-em
+    px-3 py-2 space-x-2 rounded-12 text-base font-bold
+  `}
+  >
+    {children}
+  </div>
+);
+
 export const Basic: Story = {
-  render: (args) => (
-    <Popover>
-      <PopoverTrigger className="ml-[400px] mt-4">
-        <Button>Open Popup</Button>
-      </PopoverTrigger>
-      <PopoverContent {...args}>
-        <p>This is a basic content example</p>
-      </PopoverContent>
-    </Popover>
-  ),
+  render: (args) => {
+    const basicRef = useRef(null);
+
+    return (
+      <Popover>
+        <PopoverTrigger className="ml-[400px] mt-4">
+          <TriggerElement>Open Popup</TriggerElement>
+        </PopoverTrigger>
+        <PopoverContent {...args} ref={basicRef}>
+          <p>This is a basic content example</p>
+        </PopoverContent>
+      </Popover>
+    );
+  },
 };
 
 const SettingsPopoverContent = () => (
@@ -94,28 +106,38 @@ const SettingsPopoverContent = () => (
   </div>
 );
 export const SlippageSettings: Story = {
-  render: (args) => (
-    <Popover>
-      <PopoverTrigger className="ml-[400px] mt-4">
-        <IconButton name="settings" />
-      </PopoverTrigger>
-      <PopoverContent {...args} className="max-w-md px-0">
-        <SettingsPopoverContent />
-      </PopoverContent>
-    </Popover>
-  ),
+  render: (args) => {
+    const settingsRef = useRef(null);
+
+    return (
+      <Popover>
+        <PopoverTrigger className="ml-[400px] mt-4">
+          <TriggerElement>
+            <Icon name="settings" />
+          </TriggerElement>
+        </PopoverTrigger>
+        <PopoverContent {...args} className="max-w-md px-0" ref={settingsRef}>
+          <SettingsPopoverContent />
+        </PopoverContent>
+      </Popover>
+    );
+  },
 };
 
 export const PopoverWithHeader: Story = {
-  render: (args) => (
-    <Popover>
-      <PopoverTrigger className="ml-[400px] mt-4">
-        <Button>With header</Button>
-      </PopoverTrigger>
-      <PopoverContent {...args} className="max-w-md px-0">
-        <PopoverContentHeader title="Settings" />
-        <SettingsPopoverContent />
-      </PopoverContent>
-    </Popover>
-  ),
+  render: (args) => {
+    const withHeaderRef = useRef(null);
+
+    return (
+      <Popover>
+        <PopoverTrigger className="ml-[400px] mt-4">
+          <TriggerElement>With header</TriggerElement>
+        </PopoverTrigger>
+        <PopoverContent {...args} className="max-w-md px-0" ref={withHeaderRef}>
+          <PopoverContentHeader title="Settings" />
+          <SettingsPopoverContent />
+        </PopoverContent>
+      </Popover>
+    );
+  },
 };

--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { ToggleGroup, ToggleGroupOption } from "./ToggleGroup"; // Corrected spelling here
+import { ToggleGroup, ToggleGroupOption } from ".";
 import { useState } from "react";
 
 const meta: Meta<typeof ToggleGroup> = {
-  title: "Components/ToggleGroup", // Corrected spelling here
+  title: "Components/ToggleGroup",
   component: ToggleGroup,
   parameters: {
     layout: "centered",
@@ -19,12 +19,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const ToggleGroupComponent: Story = {
-  render: args => {
+  render: (args) => {
     const [selectedValue, setSelectedValue] = useState("business");
 
     return (
       <ToggleGroup onChange={setSelectedValue} value={selectedValue} {...args}>
-        {["all", "business", "international", "politics"].map(category => (
+        {["all", "business", "international", "politics"].map((category) => (
           <ToggleGroupOption
             key={category}
             value={category}


### PR DESCRIPTION
## Fixes: 
* [SWUI-30](https://linear.app/swaprhq/issue/SWUI-30/popover-button-inside-a-button)
* [SWUI-32](https://linear.app/swaprhq/issue/SWUI-32/chipbutton-cant-recieve-refs)

# Description
* Make `Button`, `ChipButton`, and `IconButton` components able to forward refs
* Fix `Popover` website examples and Storybook docs to use buttons as children and forward refs to those children
* Move `ToggleGroup` stories to its folder
