### PR TITLE
[SWUI-35][FEAT] - Make our monorepo public

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,7 +1,6 @@
 {
   "name": "swapr-ui-website",
   "version": "0.1.5",
-  "private": true,
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "repository": "https://github.com/SwaprHQ/swapr-ui-lib",
   "version": "1.0.0",
   "license": "MIT",
-  "private": true,
   "packageManager": "bun@1.0.6",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Fixes: [SWUI-35](https://linear.app/swaprhq/issue/SWUI-35/swaprui-package-is-not-updating-the-versions)

# Description
* Removes `private` fields from our monorepo `package.json` fields