### PR TITLE
Improve Dialog component

### DIFF
--- a/apps/website/app/ui/page.tsx
+++ b/apps/website/app/ui/page.tsx
@@ -47,6 +47,7 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
+  DialogTitle,
 } from "@swapr/ui";
 
 import { PopoverSection, Section, ThemeSwitch } from "@/components";
@@ -65,7 +66,7 @@ function extractStringValuesFromObject(object: any): string[] {
         keys.push(key);
       } else if (typeof value === "object" && value) {
         const nestedKeys = extractStringValuesFromObject(value);
-        keys.push(...nestedKeys.map((nestedKey) => `${key}-${nestedKey}`));
+        keys.push(...nestedKeys.map(nestedKey => `${key}-${nestedKey}`));
       }
     }
   }
@@ -77,7 +78,7 @@ const tailwindColors: { [key: string]: Array<string> } = Object.keys(
   fullConfig.theme.colors
 ).reduce(
   (acc, key) =>
-    colorsKeysBanList.some((colorName) => colorName === key)
+    colorsKeysBanList.some(colorName => colorName === key)
       ? acc
       : {
           ...acc,
@@ -119,7 +120,7 @@ const extendBtnCombos = (
   btnPropsList: Array<ButtonListProps>,
   newProp: ExtendedButtonProps | ExtendedButtonLinkProps
 ): Array<ButtonListProps> =>
-  btnPropsList.map((buttonProps) => ({
+  btnPropsList.map(buttonProps => ({
     ...buttonProps,
     ...newProp,
   }));
@@ -451,8 +452,10 @@ export default function UI() {
                 <Button>Open</Button>
               </DialogTrigger>
               <DialogContent append="bottom">
-                <DialogHeader>Select a token</DialogHeader>
-                <DialogBody className="px-4 pb-6">
+                <DialogHeader>
+                  <DialogTitle>Select a token</DialogTitle>
+                </DialogHeader>
+                <DialogBody>
                   <ul>
                     {Array(15)
                       .fill("")
@@ -473,15 +476,13 @@ export default function UI() {
               </DialogTrigger>
               <DialogContent>
                 <DialogHeader size="xl" className="text-center">
-                  <DialogClose position="left" size="xl">
-                    <Button variant="ghost">
-                      <Icon name="arrow-left" />
-                    </Button>
+                  <DialogClose>
+                    <Icon name="arrow-left" />
                   </DialogClose>
-                  Confirm Swap
+                  <DialogTitle>Confirm Swap</DialogTitle>
                 </DialogHeader>
-                <DialogBody className="mx-10 mb-6">
-                  This action cannot be undone. This will permanently delete
+                <DialogBody>
+                  This action cannot be undone. This will permanently delete as
                   your account and remove your data from our servers.
                 </DialogBody>
                 <DialogFooter>
@@ -618,7 +619,7 @@ export default function UI() {
             .
           </p>
           <div className="divide-x divide-surface-surface-2 flex items-center space-x-5">
-            {toggleGroupOptionSizes.map((size) => (
+            {toggleGroupOptionSizes.map(size => (
               <div key={size} className="pl-4">
                 <p>Size: {size}</p>
                 <ToggleGroup value={slipage} onChange={setSlipage}>
@@ -645,8 +646,10 @@ export default function UI() {
                 <Button>Open</Button>
               </DialogTrigger>
               <DialogContent append="bottom">
-                <DialogHeader>Select a token</DialogHeader>
-                <DialogBody className="px-4 pb-6">
+                <DialogHeader>
+                  <DialogTitle>Hi I'm a Modal title</DialogTitle>
+                </DialogHeader>
+                <DialogBody>
                   <ul>
                     {Array(15)
                       .fill("")
@@ -666,13 +669,13 @@ export default function UI() {
                 <Button>Open</Button>
               </DialogTrigger>
               <DialogContent>
-                <DialogHeader size="xl" className="text-center">
-                  <DialogClose position="left" size="xl">
-                    <IconButton variant="ghost" name="arrow-left" />
+                <DialogHeader className="flex items-center">
+                  <DialogClose>
+                    <Icon size={18} name="arrow-left" />
                   </DialogClose>
-                  Confirm Swap
+                  <DialogTitle>Confirm Tx</DialogTitle>
                 </DialogHeader>
-                <DialogBody className="mx-10 mb-6">
+                <DialogBody>
                   This action cannot be undone. This will permanently delete
                   your account and remove your data from our servers.
                 </DialogBody>
@@ -701,7 +704,7 @@ export default function UI() {
         <Section>
           <h2 className="text-2xl font-semibold">Tag</h2>
           <div className="flex space-x-6">
-            {TagColorSchemes.map((color) => (
+            {TagColorSchemes.map(color => (
               <Fragment key={color}>
                 <Tag colorScheme={color as TagColorSchemeProp} size="sm">
                   Tag
@@ -790,7 +793,7 @@ export default function UI() {
         <Section>
           <h2 className="text-2xl font-semibold">Icons</h2>
           <div className="flex flex-wrap space-x-4 space-y-2 md:space-y-0">
-            {Object.keys(iconMap).map((iconName) => (
+            {Object.keys(iconMap).map(iconName => (
               <div
                 className="flex flex-col items-center space-y-2"
                 key={iconName}
@@ -896,11 +899,11 @@ export default function UI() {
         <Section>
           <h2 className="text-2xl font-semibold">Colors</h2>
           <div className="space-y-3 divide-y divide-outline-primary-base-em">
-            {Object.keys(tailwindColors).map((key) => (
+            {Object.keys(tailwindColors).map(key => (
               <div key={key} className="space-y-2.5 py-2">
                 <p className="text-xl capitalize">{key}</p>
                 <div className="space-y-2 lg:grid lg:grid-cols-3">
-                  {tailwindColors[key].map((color) => (
+                  {tailwindColors[key].map(color => (
                     <div key={color} className="flex space-x-4">
                       <div
                         className={`bg-${key}-${color} w-20 h-10 rounded-6`}

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -1,11 +1,10 @@
-import { forwardRef } from "react";
+import { forwardRef, PropsWithChildren } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { cva, cx } from "class-variance-authority";
-import { IconButton } from "../IconButton";
-
-interface SizeProp {
-  size?: "lg" | "xl" | null | undefined;
-}
+import { twMerge } from "@/utils";
+import { ButtonProps, buttonStyles } from "@/components/Button";
+import { Icon } from "@/components/Icon";
+import { iconButtonStyles, iconSize } from "@/components/IconButton";
 
 interface AppendProp {
   append?: "center" | "bottom" | null | undefined;
@@ -14,6 +13,12 @@ interface AppendProp {
 interface PositionProp {
   position?: "right" | "left" | null | undefined;
 }
+
+interface SizeProp {
+  size?: ButtonProps["size"];
+}
+
+interface DialogProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 const Dialog = DialogPrimitive.Root;
 
@@ -86,34 +91,19 @@ const DialogContent = forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const closeStyle = cva(
-  [
-    "absolute data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
-  ],
-  {
-    variants: {
-      position: { right: "", left: "" },
-      size: { lg: "", xl: "" },
-    },
-    compoundVariants: [
-      { position: "right", size: "lg", class: ["top-4 right-4"] },
-      { position: "left", size: "lg", class: ["top-4 left-4"] },
-      { position: "right", size: "xl", class: ["top-5 right-5"] },
-      { position: "left", size: "xl", class: ["top-5 left-5"] },
-    ],
-    defaultVariants: { position: "right", size: "lg" },
-  }
-);
-
 const DialogClose = forwardRef<
   React.ElementRef<typeof DialogPrimitive.Close>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close> &
     PositionProp &
     SizeProp
->(({ className, position, size, children, ...props }, ref) => (
+>(({ className, children, size, ...props }, ref) => (
   <DialogPrimitive.Close
     ref={ref}
-    className={closeStyle({ position, size, className })}
+    className={twMerge(
+      "data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
+      buttonStyles({ variant: "ghost" }),
+      iconButtonStyles({ className, size })
+    )}
     {...props}
   >
     {children}
@@ -124,33 +114,35 @@ DialogClose.displayName = DialogPrimitive.Close.displayName;
 
 const DialogHeader = ({
   className,
-  size,
+  size = "md",
+  children,
   ...props
-}: React.HTMLAttributes<HTMLDivElement> & SizeProp) => (
-  <>
-    <DialogClose position="right" size={size}>
-      <IconButton name="cross" variant="ghost" />
+}: DialogProps & SizeProp & PropsWithChildren) => (
+  <div
+    className={twMerge(
+      "flex items-center justify-between p-3 md:p-4",
+      className,
+      size
+    )}
+    {...props}
+  >
+    {children}
+    <DialogClose size={size}>
+      <Icon name="cross" size={iconSize[size]} />
     </DialogClose>
-    <DialogTitle className={cx("p-6", className)} {...props} />
-  </>
+  </div>
 );
 DialogHeader.displayName = "DialogHeader";
 
-const DialogBody = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cx("overflow-auto", className)} {...props} />
+const DialogBody = ({ className, ...props }: DialogProps) => (
+  <div className={twMerge("overflow-auto p-3 md:p-4", className)} {...props} />
 );
 DialogBody.displayName = "DialogBody";
 
-const DialogFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+const DialogFooter = ({ className, ...props }: DialogProps) => (
   <div
     className={cx(
-      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end p-2",
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end p-3 md:p-4",
       className
     )}
     {...props}
@@ -158,18 +150,13 @@ const DialogFooter = ({
 );
 DialogFooter.displayName = "DialogFooter";
 
-const titleStyle = cva(["font-bold"], {
-  variants: { size: { lg: "text-lg", xl: "text-xl" } },
-  defaultVariants: { size: "lg" },
-});
-
 const DialogTitle = forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> & SizeProp
->(({ className, size, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={titleStyle({ size, className })}
+    className={twMerge("text-md md:text-lg font-bold", className)}
     {...props}
   />
 ));

--- a/packages/ui/src/components/Icon/Icon.tsx
+++ b/packages/ui/src/components/Icon/Icon.tsx
@@ -216,7 +216,7 @@ export interface IconProps {
   size?: number;
 }
 
-export const Icon = ({ alt, className, name, size = 20 }: IconProps) => {
+export const Icon = ({ alt, className, name, size = 18 }: IconProps) => {
   const IconComponent = iconMap[name];
 
   return (

--- a/packages/ui/src/components/IconButton/IconButton.tsx
+++ b/packages/ui/src/components/IconButton/IconButton.tsx
@@ -19,7 +19,7 @@ export const iconButtonStyles = cva([], {
 });
 
 type Size = NonNullable<ButtonProps["size"]>;
-const iconSize: Record<Size, number> = {
+export const iconSize: Record<Size, number> = {
   xs: 14,
   sm: 14,
   md: 18,


### PR DESCRIPTION
The Dialog Modal should have good defaults to be used out of the box but also be able to add custom spacing. This wasn't possible with previous implementation.

You can see inconsistence in spacing in this example on Presagio:

<img width="479" alt="image" src="https://github.com/user-attachments/assets/a4a6aef5-7e04-4389-911e-178dd322e6ec">


## Summary  
**Dialog Component**
- add default minimal padding which can be opt out
- fixes bug: remove nesting buttons (we were rendering `IconButton` inside `DialogClose`, which is also a button).  This fixes validate DOM warning.
- improve DialogHeader
- better defaults on mobile


**Example**
This is just using our component without extra classnames.
<img width="705" alt="image" src="https://github.com/user-attachments/assets/9380d3f3-d1d2-4713-be37-c215841ece25">
<img width="398" alt="image" src="https://github.com/user-attachments/assets/5de08fc4-30a2-4640-98bb-0214ea5254ac">
